### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Python ${{ matrix.python-version }} (Windows)
     runs-on: windows-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/borowka-obs/hevelius-runner/security/code-scanning/2](https://github.com/borowka-obs/hevelius-runner/security/code-scanning/2)

In general, the fix is to explicitly declare the minimal required `GITHUB_TOKEN` permissions in the workflow, either at the root level (applying to all jobs) or at the job level (scoped just to that job). For this workflow, the job only checks out code, sets up Python, installs dependencies, and runs tests; no write operations against the GitHub API are needed. Therefore, `contents: read` (and no additional write scopes) is sufficient and safest.

The single best fix here is to add a `permissions:` block to the `test` job definition in `.github/workflows/pytest.yml`, directly under `runs-on: windows-latest`, so that only this job is affected and behavior is clear. The block should set `contents: read`. This does not require any imports, methods, or additional definitions, since it is purely a YAML configuration change.

Concretely:
- Edit `.github/workflows/pytest.yml`.
- Within the `jobs.test` section, insert:

```yaml
    permissions:
      contents: read
```

right after `runs-on: windows-latest`. No other parts of the workflow need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
